### PR TITLE
Extend history

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "express": "^4.17.1",
     "gambar": "github:jtanadi/gambar#master",
+    "lodash": "^4.17.15",
     "nanoid": "^2.1.11",
     "react": "^16.9.0",
     "react-color": "^2.18.0",

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components"
 import Gambar from "gambar"
 import { Shape } from "gambar/src/geometry"
 import nanoid from "nanoid"
+import _ from "lodash"
 
 import ToolPalette from "./ToolPalette"
 import CanvasWindow from "./CanvasWindow"
@@ -203,11 +204,20 @@ const App: React.FC<{}> = (): ReactElement => {
     if (!selectedShapes.length) {
       setAppFillColor(rgba)
     } else {
-      // maybe not the right way of doing this
+      // Maybe not the right way of doing this
       // or not the right place for this
-      for (const [shape] of selectedShapes) {
-        shape.fillColor = rgba
-      }
+      // See if this should be handled by Gambar
+      const currentDrawing = drawings[drawings.length - 1]
+      currentDrawing.shapes = currentDrawing.shapes.map(shape => {
+        if (shape.selected) {
+          // To keep track of history, we have to make a copy
+          // of objects with new fillColor
+          const newShape = _.cloneDeep(shape)
+          newShape.fillColor = rgba
+          return newShape
+        }
+        return shape
+      })
     }
     setCurrentFillColor(rgba)
   }
@@ -217,11 +227,16 @@ const App: React.FC<{}> = (): ReactElement => {
     if (!selectedShapes.length) {
       setAppStrokeColor(rgba)
     } else {
-      // maybe not the right way of doing this
-      // or not the right place for this
-      for (const [shape] of selectedShapes) {
-        shape.strokeColor = rgba
-      }
+      // Same note as handleFillColor
+      const currentDrawing = drawings[drawings.length - 1]
+      currentDrawing.shapes = currentDrawing.shapes.map(shape => {
+        if (shape.selected) {
+          const newShape = _.cloneDeep(shape)
+          newShape.strokeColor = rgba
+          return newShape
+        }
+        return shape
+      })
     }
     setCurrentStrokeColor(rgba)
   }

--- a/src/components/ToolPalette/index.tsx
+++ b/src/components/ToolPalette/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react"
+import React, { ReactElement, useEffect, useState } from "react"
 import Draggable from "react-draggable"
 import { SketchPicker } from "react-color"
 
@@ -23,7 +23,7 @@ type PropTypes = {
   displayFillPicker: boolean
   displayStrokePicker: boolean
   pickTool(type: DrawingToolTypes): void
-  handleHistory(action: HistoryActions): void
+  handleHistory(action?: HistoryActions): void
   changeLayerOrder(action: LayerActions): void
   onFillColorChange(color): void
   onStrokeColorChange(color): void
@@ -45,6 +45,18 @@ const ToolPalette: React.FC<PropTypes> = ({
   onFillColorClick,
   onStrokeColorClick,
 }): ReactElement => {
+  const [firstLoad, setFirstLoad] = useState(true)
+  useEffect(() => {
+    // Only record color history when fillPicker and strokePicker
+    // aren't displayed (ie. when user is completely done picking colors)
+    // firstLoad is a bit hacky--we don't want handleHistory() to be called
+    // when this component is first loaded
+    if (!firstLoad && !displayFillPicker && !displayStrokePicker) {
+      handleHistory()
+    }
+    setFirstLoad(false)
+  }, [displayFillPicker, displayStrokePicker])
+
   return (
     <Draggable handle=".palette-bar" bounds="body">
       <PaletteWrapper>
@@ -77,11 +89,7 @@ const ToolPalette: React.FC<PropTypes> = ({
         ) : null}
         {displayStrokePicker ? (
           <Popover stroke={true.toString()}>
-            <SketchPicker
-              color={strokeColor}
-              onChange={onStrokeColorChange}
-              onChangeComplete={onStrokeColorChange}
-            />
+            <SketchPicker color={strokeColor} onChange={onStrokeColorChange} />
           </Popover>
         ) : null}
       </PaletteWrapper>


### PR DESCRIPTION
- First pass of tracking history of fill and stroke colors
- In the current implementation, a deep copy of each modified object is created within a shallow copy of `currentDrawing.shapes`
    - This might be something for the Gambar library to take care of instead